### PR TITLE
Fix custom objects addition with type=json

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -8,7 +8,7 @@ Celestial.add = function(dat) {
   //  with size,shape,color: "prop=val:result;.." || function(prop) { .. return res; } 
   if (!has(dat, "type")) return console.log("Missing type");
   
-  if ((dat.type === "dso" || dat.type === "json") && (!has(dat, "file") || !has(dat, "callback"))) return console.log("Can't add data file");
+  if ((dat.type === "dso" || dat.type === "json") && (!has(dat, "file") && !has(dat, "callback"))) return console.log("Can't add data file");
   if ((dat.type === "line" || dat.type === "raw") && !has(dat, "callback")) return console.log("Can't add line");
   
   if (has(dat, "file")) res.file = dat.file;


### PR DESCRIPTION
Correct me if I'm wrong, but here the logic should be an ``&&``. You want to add an dat if it has *at least* a callback or a file, but it doesn't need to be both of them, right?