### PR TITLE
Set the date and location externally and move the map

### DIFF
--- a/celestial.js
+++ b/celestial.js
@@ -2521,6 +2521,15 @@ function geo(cfg) {
     }
   }
 
+  Celestial._location = function (lat, lon) {
+    $("lat").value = lat;
+    $("lon").value = lon;
+  }
+
+  Celestial._go = function () {
+    go();
+  };
+
   Celestial.getPosition = function (p) {
     
   };

--- a/demo/custom-date-location.html
+++ b/demo/custom-date-location.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <title>D3-Celestial Starry Custom Sky Map</title>
+  <script type="text/javascript" src="../lib/d3.min.js"></script>
+  <script type="text/javascript" src="../lib/d3.geo.projection.min.js"></script>
+  <script type="text/javascript" src="../celestial.js"></script>
+  <link rel="stylesheet" href="../celestial.css">
+</head><body>
+<div style="overflow:hidden;"><div id="celestial-map"></div></div>
+<div id="celestial-form"></div>
+<button id="time_button">Change time</button>
+<button id="location_button">Change location</button>
+<script type="text/javascript">
+/* D3-Celestial sky map
+   Copyright 2015 Olaf Frohn https://github.com/ofrohn, see LICENSE
+
+*/
+// Properties different from default
+var config = {
+  location: true,
+  interactive: true,
+  controls: false,
+  projection: "stereographic",
+  datapath: "../data/",
+};
+Celestial.display(config);
+
+document.getElementById("time_button").onclick = () => {
+    Celestial.date(new Date(2019, 8-1, 25, 23, 0, 0));
+    Celestial._go();
+}
+
+document.getElementById("location_button").onclick = () => {
+    Celestial._location(-43, 42);
+    Celestial._go();
+}
+
+</script>
+<footer id="d3-celestial-footer">
+<p><a href="https://github.com/ofrohn/d3-celestial"><b>D3-Celestial</b></a> released under <a href="http://opensource.org/licenses/BSD-3-Clause">BSD license</a>. Copyright 2015-17 <a href="http://armchairastronautics.blogspot.com/" rel="author">Olaf Frohn</a>.
+</p></footer>
+</body>
+</html>


### PR DESCRIPTION
Hi, first of all thank you very much for maintaining this library.

For [my project](https://github.com/martinber/dark-sky-planner) I need to show the sky on a given location and time. (Also I don't want to use the embedded form so I just hide it using CSS).

As far as I know the available methods for configuring time and location are:

- Set location on `config.geopos` before doing `Celestial.display(config)` for the first time.
- Set location using the embedded form (should be done manually by the user).
- Set time using the embedded form (should be done manually by the user).
- Set time using `Celestial.date(date)` (but you can't see the change until the user does some modifications to the embedded form). (Note #20)

I think that adding a `Celestial.location(lat, lon)` function makes sense given that `Celestial.date(date)` already exists. Also, `Celestial.apply()` should move the map if used after any of the previous functions.

Example usage:

```
document.getElementById("go_home").onclick = () => {
    Celestial.date(tonight);
    Celestial.location(home.lat, home.lon);
    Celestial.apply();
}
```

# How I modified Celestial to make it work

I made this issue a Pull Request so you can see a working example of the modifications I did. For now the workaround is:

- Add a `Celestial._location(lat, lon)` function to edit the "lat" and "lon" form input fields.
- Add a `Celestial._go()` function to call the private `go()` function, first I tried to edit the `Celestial.apply()` function and add a call to `go()` there but it didn't work, so I made a new function. 

# Recommendations

I would do some modifications to this library to make it independent from the location and time forms, right now I need to add a hidden `celestial-form` div if I want to set the time and location. Then I would add `Celestial.location(lat, lon)` and make `Celestial.apply()` update the changes.

What do you think? If I take my time I think I can make a better pull request but I don't know the best way to implement it yet.

EDIT: On my project I had to comment out line 2539 of `celestial.js` that says `if (dtpick.isVisible()) return;`. Because of that line I can't change the date because for some reason `dtpick` is visible.
