### PR TITLE
Documentation

### DIFF
--- a/data/readme.md
+++ b/data/readme.md
@@ -1,9 +1,10 @@
-### Data Formats
+# Data Formats
 
 For GeoJSON, all coordinates need to be given in degrees, longitude as [-180...180] deg, latitude as [-90...90] deg
 
-__Stars__  
-`stars.6.json`, `stars.8.json`; the number indicates limit magnitude  
+## Stars
+
+`stars.6.json`, `stars.8.json`: the number indicates limit magnitude  
 
 ```js
 {
@@ -25,7 +26,8 @@ __Stars__
 }
 ```
 
-__DSOs__  
+## DSOs
+
 `dsos.6.json`, `dsos.14.json`: the number indicates limit magnitude  
 `dsos.bright.json`: handselected  
 `lf.json`: Local group  
@@ -39,7 +41,7 @@ __DSOs__
     "properties": {
       "name": "",   // Proper name or most commonly used designator
       "desig": "",  // Designator
-      "type": "",   // Object type: gg, g, s, s0, ds, i, e, oc, gc, dn, bn, sfr, rn, pn, snr
+      "type": "",   // Object type: gg, g, s, s0, sd, i, e, oc, gc, dn, bn, sfr, rn, en, pn, snr
       "mag": "",    // Apparent magnitude, 999 if n.a.
       "dim": ""     // Angular dimensions in arcminutes
     },
@@ -49,17 +51,18 @@ __DSOs__
     }
   }, { } ]
 }
-```  
-___Object type___ _gg_: galaxy cluster, _g_: galaxy, _s_: spiral galaxy, _s0_: lenticular gal., _ds_: dwarf gal., _i_: irregular gal., _e_: elliptical gal.,  
-_oc_: open cluster, _gc_: globular cluster, _dn_: dark nebula, _bn_: bright nebula, _sfr_: star forming region, _rn_: reflection nebula, _pn_: planetary nebula, _snr_: supernova remnant  
+```
+
+___Object type:___ _gg_: galaxy cluster, _g_: galaxy, _s_: spiral galaxy, _s0_: lenticular gal., _sd_: dwarf spheroidal gal., _i_: irregular gal., _e_: elliptical gal., _oc_: open cluster, _gc_: globular cluster, _dn_: dark nebula, _bn_: bright nebula, _sfr_: star forming region, _rn_: reflection nebula, _en_: emission nebula, _pn_: planetary nebula, _snr_: supernova remnant
 
 ___additional lg.json properties:___  
 _sub_: Sub group membership: \[MW|M31|N3109|LG\]  (Milky way, Andromeda, NGC 3109, gen. LG)  
 _pop_: MW popultions \[OH|YH|BD\] (Old halo, young halo, bulge & disk), M31 populations \[M31|GP\]  (gen. M31, great plane)  
 _str_: Tidal streams \[Mag|Sgr|CMa|FLS\] (Magellanic Stream, Sagittarius Stream, Canis Major/Monoceros Stream, Fornax-Leo-Sculptor Great Circle)
 
-__Constellations__  
-`constellations.json`  
+## Constellations
+
+`constellations.json`
 
 ```js
 {
@@ -81,8 +84,9 @@ __Constellations__
 }
 ```
 
-__Constellation lines__  
-`constellations.lines.json`  
+## Constellation lines
+
+`constellations.lines.json`
 
 ```js
 {
@@ -98,8 +102,9 @@ __Constellation lines__
 }
 ```
 
-__Constellation boundaries__  
-`constellations.bounds.json`  
+## Constellation boundaries
+
+`constellations.bounds.json`
 
 ```js
 {
@@ -115,8 +120,9 @@ __Constellation boundaries__
 }
 ```
 
-__Milky way__  
-`mw.json`  
+## Milky way
+
+`mw.json`
 
 ```js
 {
@@ -133,7 +139,7 @@ __Milky way__
 }
 ```
 
-__Special Planes__
+## Special Planes
 
 ```js
 {
@@ -149,7 +155,7 @@ __Special Planes__
 }
 ```
 
-__Asterisms__  
+## Asterisms
 
 ```js
 {
@@ -172,10 +178,11 @@ __Asterisms__
 }
 ```
 
-__Planets__
+## Planets
+
 Not geojson, because positions need to be calculated by date from keplerian elements  
 All element values in degrees, except a (AU|km) and e (dimensionless)  
-  
+
 ```js
 "id":{                // (usually) 3-letter id
   "name": "",         // full name

--- a/demo/triangle.html
+++ b/demo/triangle.html
@@ -82,7 +82,7 @@ Celestial.add({type:"line", callback: function(error, json) {
   // Load the geoJSON file and transform to correct coordinate system, if necessary
   var asterism = Celestial.getData(jsonLine, config.transform);
 
-  // Add to celestiasl objects container in d3
+  // Add to celestial objects container in d3
   Celestial.container.selectAll(".asterisms")
     .data(asterism.features)
     .enter().append("path")

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,15 @@ __Some more examples__:
 
 ### Usage
 
-Include the necessary scripts d3.min.js, d3.geo.projection.min.js and celestial.js from the `lib` subfolder or the first two alternatively from the official d3.js server `http://d3js.org/`, and then simply edit the default options and display the map with `Celestial.display(config)`.
+* On your HTML add a div with some id, e.g.: `<div id="celestial-map"></div>`.
+
+* Optionally add a div with the id "celestial-form" if you are going to use some of the built-in forms: `<div id="celestial-form"></div>`.
+
+* Include the d3-celestial script, available as `celestial.js` or `celestial.min.js`.
+
+* Include the necessary d3 scripts: `d3.min.js` and `d3.geo.projection.min.js`. Available on the `lib` subfolder in this repository or from the official d3.js server `http://d3js.org/`.
+
+* On your script display the map with `Celestial.display(config)`. Remember to indicate the id of the div where the map will be shown. Check and edit the following default configuration file.
 
 ```js
 var config = { 
@@ -51,8 +59,10 @@ var config = {
   zoomextend: 10,     // maximum zoom level
   adaptable: true,    // Sizes are increased with higher zoom-levels
   interactive: true,  // Enable zooming and rotation with mousewheel and dragging
-  form: true,         // Display form for interactive settings
-  location: false,    // Display location settings (no center setting on form)
+  form: true,         // Display form for interactive settings. Needs a div with
+                      // id="celestial-form"
+  location: false,    // Display location settings (no center setting on form).
+                      // Needs a div with id="celestial-form"
   daterange: [],      // Calender date range; null: displaydate-+10; [n<100]: displaydate-+n; [yr]: yr-+10; 
                       // [yr, n<100]: [yr-n, yr+n]; [yr0, yr1]  
   controls: true,     // Display zoom controls
@@ -186,7 +196,7 @@ var config = {
   }
 };
 
-// Display map with the configuration above or any subset therof
+// Display map with the configuration above or any subset thereof
 Celestial.display(config);
 ```
 


### PR DESCRIPTION
Hi, I'm trying to add some documentation.

Changes I made:

-  Fix documentation on DSO object types on `/data/readme.md`:  
   Dwarf galaxy" should be "Dwarf spheroidal galaxy", on JSON appears as `sd`
   instead of `ds`.  
   Also added "en" as "Emission nebula" because I found it on `dsos.json` but it wasn't on the
   documentation.

-  Changed the style of the headers on `/data/readme.md`

-  Tried to document better on how to use the library

- Tried to document that you need a `#celestial-form` when you set `config.location` or `config.form`
   to true

Now I wanted to document better on how to add markers/lines/things to the map and I have some questions:

- What is the purpose of the `file` and `type` arguments on `Celestial.add()`?

   On the documentation its says "Type is 'json' for JSON-Formatted data" and "The file argument is optional for providing an external geoJSON file; since we already defined our data, we don't need it. Type is 'line'". Also the readme says `type:json|raw` but the code also checks for `dso` and `line`.

   I would indicate the common pairs of `file` and `type` for each use case.

- When adding data to the d3 container, why do we use two different classes?. E.g. in `triangle.md` we use `asterisms` and `ast`
  ```
  Celestial.container.selectAll(".asterisms")
      .data(asterism.features)
      .enter().append("path")
      .attr("class", "ast"); 
   ```
   Y think they should be the same, so when we add more asterisms the ones already present on the container are not added again

Thank you very much